### PR TITLE
fpga-bootloading-changes-phase-1-PR-3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ synlog.tcl
 *bak
 gerbers/
 build/
+**/__pycache__/


### PR DESCRIPTION
This is PR-3 for the fpga-bootloading-changes-phase-1.
Summary of changes:
- added support for `--appfpga` option and logic to write the fpga binary image to correct flash location (and its metadata)
- added a helper function `reset_meta()` to reset metadata associated with a specific image
- cannot use both `--appfpga` and `--m4app` option together, using either one will cause the metadata of the other to be reset(to 0xFFFFFFFF)
- no flash memory map changes
- (minor) add `__pycache__` dirs to gitignore

Support for simultaneous usage of `--m4app` and `--appfpga` will be added in phase 2.

**NOTE**: This is a draft PR, until the FPGA toolchain supports the generation of the FPGA binary in mainline/release.
Once the FPGA Toolchain PRs are merged/release, this can be moved to a PR and merged.